### PR TITLE
Fix non-existing version in pom dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dependency ( [![Maven Central](https://img.shields.io/maven-central/v/de.flapdoo
     <dependency>
          <groupId>de.flapdoodle.embed</groupId>
          <artifactId>de.flapdoodle.embed.mongo</artifactId>
-         <version>4.9.3</version>
+         <version>4.9.2</version>
     </dependency>
 
 ### Usage


### PR DESCRIPTION
There is no v4.9.3 on mvn central (yet), so the project won't compile erroring with:

> Could not find artifact de.flapdoodle.embed:de.flapdoodle.embed.mongo:jar:4.9.3 in central (https://repo.maven.apache.org/maven2)